### PR TITLE
fix(conn): no pingreq is sent when use ./emqtt_bench conn

### DIFF
--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -301,8 +301,12 @@ connect(Parent, N, PubSub, Opts) ->
                 {tcp_opts, tcp_opts(Opts)},
                 {ssl_opts, ssl_opts(Opts)}
                | mqtt_opts(Opts)],
+    MqttOpts1 = case PubSub of
+                  conn -> [{force_ping, true} | MqttOpts];
+                  _ -> MqttOpts
+                end,
     AllOpts  = [{seq, N}, {client_id, ClientId} | Opts],
-	{ok, Client} = emqtt:start_link(MqttOpts),
+	{ok, Client} = emqtt:start_link(MqttOpts1),
     ConnRet = case proplists:get_bool(ws, Opts) of
                   true  -> 
                       emqtt:ws_connect(Client);


### PR DESCRIPTION

./emqtt_bench conn -c 50000 -i 50 -h 192.168.1.50 --ifaddr=192.168.1.150

```
** Reason for termination = exit:{disconnected,141,#{}}
** Callback modules = [emqtt]
** Callback mode = state_functions
** Stacktrace =
**  [{gen_statem,loop_state_callback_result,11,
                 [{file,"gen_statem.erl"},{line,1312}]},
     {proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,259}]}]

client(43376): EXIT for {disconnected,141,#{}}
=CRASH REPORT==== 4-Nov-2020::13:45:59.346584 ===
  crasher:
    initial call: emqtt:init/1
    pid: <0.13362.0>
    registered_name: []
    exception exit: {disconnected,141,#{}}
      in function  gen_statem:loop_state_callback_result/11 (gen_statem.erl, line 1312)
    ancestors: [<0.13361.0>]
    message_queue_len: 0
    messages: []
    links: [<0.13361.0>]
    dictionary: [{send_oct,58}]
    trap_exit: true
    status: running
    heap_size: 610
    stack_size: 27
    reductions: 14074
  neighbours:
```