### PR TITLE
Modify client id key of MqttOpts

### DIFF
--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -303,7 +303,7 @@ connect(Parent, N, PubSub, Opts) ->
     process_flag(trap_exit, true),
     rand:seed(exsplus, erlang:timestamp()),
     ClientId = client_id(PubSub, N, Opts),
-    MqttOpts = [{client_id, ClientId},
+    MqttOpts = [{clientid, ClientId},
                 {tcp_opts, tcp_opts(Opts)},
                 {ssl_opts, ssl_opts(Opts)}
                | mqtt_opts(Opts)],


### PR DESCRIPTION
Because client id key is different, it is not applied to mqtt connection setting.

Reference
https://github.com/emqx/emqtt#exports
emqtt:start_link(Options)
{clientid, ClientID}
Specify the client identifier. If not given, the client identifier will use the value assigned by the server in MQTT v5 or be automatically generated by internal code in MQTT v3.1/v3.1.1.