### PR TITLE
Add client id prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Usage: emqtt_bench conn [--help <help>] [-h [<host>]] [-p [<port>]]
                         [-i [<interval>]] [-u <username>] [-P <password>]
                         [-k [<keepalive>]] [-C [<clean>]] [-S [<ssl>]]
                         [--certfile <certfile>] [--keyfile <keyfile>]
-                        [--ifaddr <ifaddr>]
+                        [--ifaddr <ifaddr>] [--prefix <prefix>]
 
   --help             help information
   -h, --host         mqtt server hostname or IP address [default:
@@ -39,6 +39,7 @@ Usage: emqtt_bench conn [--help <help>] [-h [<host>]] [-p [<port>]]
   --keyfile          client private key for authentication, if required by
                      server
   --ifaddr           local ipaddress or interface address
+  --prefix           client id prefix
 ```
 
 For example, create 50K concurrent connections at the arrival rate of 100/sec:
@@ -58,7 +59,7 @@ Usage: emqtt_bench sub [--help <help>] [-h [<host>]] [-p [<port>]]
                        [-P <password>] [-k [<keepalive>]] [-C [<clean>]]
                        [-S [<ssl>]] [--certfile <certfile>]
                        [--keyfile <keyfile>] [--ws [<ws>]]
-                       [--ifaddr <ifaddr>]
+                       [--ifaddr <ifaddr>] [--prefix <prefix>]
 
   --help             help information
   -h, --host         mqtt server hostname or IP address [default: localhost]
@@ -78,6 +79,7 @@ Usage: emqtt_bench sub [--help <help>] [-h [<host>]] [-p [<port>]]
   --keyfile          client private key for authentication, if required by server
   --ws               websocket transport [default: false]
   --ifaddr           local ipaddress or interface address
+  --prefix           client id prefix
 ```
 
 For example, create 50K concurrent connections at the arrival rate of 100/sec: 
@@ -98,7 +100,7 @@ Usage: emqtt_bench pub [--help <help>] [-h [<host>]] [-p [<port>]]
                        [-q [<qos>]] [-r [<retain>]] [-k [<keepalive>]]
                        [-C [<clean>]] [-S [<ssl>]]
                        [--certfile <certfile>] [--keyfile <keyfile>]
-                       [--ws [<ws>]] [--ifaddr <ifaddr>]
+                       [--ws [<ws>]] [--ifaddr <ifaddr>] [--prefix <prefix>]
 
   --help                 help information
   -h, --host             mqtt server hostname or IP address [default: localhost]
@@ -122,6 +124,7 @@ Usage: emqtt_bench pub [--help <help>] [-h [<host>]] [-p [<port>]]
   --keyfile              client private key for authentication, if required by server
   --ws                   websocket transport [default: false]
   --ifaddr               local ipaddress or interface address
+  --prefix               client id prefix
 ```
 
 For example, create 100 connections and each publishes messages at the rate of 100 msg/sec.

--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -67,7 +67,8 @@
          {ws, undefined, "ws", {boolean, false},
           "websocket transport"},
          {ifaddr, undefined, "ifaddr", string,
-          "local ipaddress or interface address"}
+          "local ipaddress or interface address"},
+         {prefix, undefined, "prefix", string, "client id prefix"}
         ]).
 
 -define(SUB_OPTS,
@@ -105,7 +106,8 @@
          {ws, undefined, "ws", {boolean, false},
           "websocket transport"},
          {ifaddr, undefined, "ifaddr", string,
-          "local ipaddress or interface address"}
+          "local ipaddress or interface address"},
+         {prefix, undefined, "prefix", string, "client id prefix"}
         ]).
 
 -define(CONN_OPTS, [
@@ -137,7 +139,8 @@
          {keyfile, undefined, "keyfile", string,
           "client private key for authentication, if required by server"},
          {ifaddr, undefined, "ifaddr", string,
-          "local ipaddress or interface address"}
+          "local ipaddress or interface address"},
+         {prefix, undefined, "prefix", string, "client id prefix"}
         ]).
 
 -define(TAB, ?MODULE).
@@ -444,8 +447,14 @@ client_id(PubSub, N, Opts) ->
         IfAddr    ->
             IfAddr
     end,
-    list_to_binary(lists:concat([Prefix, "_bench_", atom_to_list(PubSub),
-                                    "_", N, "_", rand:uniform(16#FFFFFFFF)])).
+    case proplists:get_value(prefix, Opts) of
+        undefined ->
+            list_to_binary(lists:concat([Prefix, "_bench_", atom_to_list(PubSub),
+                                    "_", N, "_", rand:uniform(16#FFFFFFFF)]));
+        Val ->
+            list_to_binary(lists:concat([Val, "_bench_", atom_to_list(PubSub),
+                                    "_", N]))
+    end.
 
 topics_opt(Opts) ->
     Topics = topics_opt(Opts, []),


### PR DESCRIPTION
add for setting ACL for benchmark.
so, if client id prefix is set, random value is not added.