### PR TITLE
chore: hibernate processes to save memory consumption

### DIFF
--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -359,6 +359,9 @@ loop(Parent, N, Client, PubSub, Opts) ->
             loop(Parent, N, Client, PubSub, Opts);
         {'EXIT', Client, Reason} ->
             io:format("client(~w): EXIT for ~p~n", [N, Reason])
+    after
+        15000 ->
+            proc_lib:hibernate(?MODULE, loop, [Parent, N, Client, PubSub, Opts])
 	end.
 
 consumer_pub_msg_fun_init(0) ->


### PR DESCRIPTION
We can hibernate processes to reduce memory usage, especially when using the `conn` and `sub` commands

