### PR TITLE
Docker Build Pipeline based on GIthub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: docker/metadata-action@v3
         id: meta
         with:
-          images: ghcr.io/1995parham/emqtt-bench
+          images: ghcr.io/${{ github.repository_owner }}/emqtt-bench
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,10 @@
 ---
 name: build
 on:
-  - push
+  push:
+    tags:
+      - "*"
+      - "!v*"
 jobs:
   docker:
     name: docker

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,33 @@
+---
+name: build
+on:
+  - push
+jobs:
+  docker:
+    name: docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v3
+        id: meta
+        with:
+          images: ghcr.io/1995parham/emqtt-bench
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
We are using `emqtt-bench` on Kubernetes to load test our cluster and I think having an available image for `emqtt-bench` can help people to run these types of load tests more easily.

The current configuration builds the image always with the master tag based on the latest commit on the master branch. also, it builds a tagged image whenever you created a tag.