### PR TITLE
fix(sub_fail): reason code must be binary

### DIFF
--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -516,7 +516,7 @@ subscribe(Client, Opts) ->
             inc_counter(sub);
         {error, _Reason} ->
             inc_counter(sub_fail),
-            emqtt:disconnect(Client, sub_fail)
+            emqtt:disconnect(Client, <<"sub_fail">>)
     end,
     Res.
 


### PR DESCRIPTION
If an atom is supplied as the reason code, `emqtt:disconnect` will
fail to serialize such reason code:

```
=CRASH REPORT==== 15-Dec-2021::11:02:06.695317 ===
  crasher:
    initial call: emqtt:init/1
    pid: <0.193.0>
    registered_name: []
    exception error: bad argument
      in function  iolist_size/1
         called as iolist_size([sub_fail,<<0>>])
         *** argument 1: not an iodata term
      in call from emqtt_frame:serialize/3 (/home/thales/dev/emqx/emqtt/src/emqtt_frame.erl, line 477)
      in call from emqtt:send/2 (/home/thales/dev/emqx/emqtt/src/emqtt.erl, line 1331)
      in call from emqtt:connected/3 (/home/thales/dev/emqx/emqtt/src/emqtt.erl, line 821)
      in call from gen_statem:loop_state_callback/11 (gen_statem.erl, line 1194)
    ancestors: [<0.187.0>]
    message_queue_len: 0
    messages: []
    links: [<0.187.0>]
    dictionary: []
    trap_exit: true
    status: running
    heap_size: 10958
    stack_size: 29
    reductions: 21923
```