### PR TITLE
fix: fix bad startnumber on multiple addrs

### DIFF
--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -254,7 +254,7 @@ start(PubSub, Opts) ->
     Rem = Count rem NoWorkers,
     Interval = proplists:get_value(interval, Opts) * NoWorkers,
     lists:foreach(fun(P) ->
-                          StartNumber = proplists:get_value(startnumber, Opts) + CntPerWorker*P,
+                          StartNumber = proplists:get_value(startnumber, Opts) + CntPerWorker*(P-1),
                           CountParm = case Rem =/= 0 andalso P == 1 of
                                           true ->
                                               [{count, CntPerWorker + Rem}];


### PR DESCRIPTION
The bug causes the initial value of the client id to be calculated incorrectly

For example:
```
./emqtt_bench conn -c 10 -k 15 -n 0 --prefix abcd
```

<img width="550" alt="image" src="https://user-images.githubusercontent.com/13825269/146865091-c66f6b56-7876-43ef-901c-7a7362973554.png">
