### PR TITLE
fix: return valid reason code when disconnecting

### DIFF
--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -16,6 +16,8 @@
 
 -module(emqtt_bench).
 
+-include_lib("emqtt/include/emqtt.hrl").
+
 -export([ main/1
         , main/2
         , start/2
@@ -529,7 +531,7 @@ subscribe(Client, Opts) ->
             inc_counter(sub);
         {error, _Reason} ->
             inc_counter(sub_fail),
-            emqtt:disconnect(Client, <<"sub_fail">>)
+            emqtt:disconnect(Client, ?RC_UNSPECIFIED_ERROR)
     end,
     Res.
 


### PR DESCRIPTION
`emqtt:disconnect/2` actually expects a reason code as the second
argument instead of a binary.

https://github.com/emqx/emqtt/blob/8604b50681649a4effa5a78873c9e6ebb66c9e31/src/emqtt.erl#L409