### PR TITLE
docs: fix readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,14 +190,14 @@ For example, create 100 connections and each publishes messages at the rate of 1
 ## One-way SSL Socket
 
 ```sh
-./emqtt_bench sub -c 100 -i 10 -t bench/%i -p 8883 -S
-./emqtt_bench pub -c 100 -I 10 -t bench/%i -p 8883 -s 256 -S
+./emqtt_bench sub -c 100 -i 10 -t bench/%i -p 8883 --ssl
+./emqtt_bench pub -c 100 -I 10 -t bench/%i -p 8883 -s 256 --ssl
 ```
 
 ## Two-way SSL Socket
 ```sh
-./emqtt_bench sub -c 100 -i 10 -t bench/%i -p 8883 --certfile path/to/client-cert.pem --keyfile path/to/client-key.pem
-./emqtt_bench pub -c 100 -i 10 -t bench/%i -s 256 -p 8883 --certfile path/to/client-cert.pem --keyfile path/to/client-key.pem
+./emqtt_bench sub -c 100 -i 10 -t bench/%i -p 8883 --ssl --certfile path/to/client-cert.pem --keyfile path/to/client-key.pem
+./emqtt_bench pub -c 100 -i 10 -t bench/%i -s 256 -p 8883 --ssl --certfile path/to/client-cert.pem --keyfile path/to/client-key.pem
 ```
 
 ## Notice

--- a/README_FOR_DOCKER.md
+++ b/README_FOR_DOCKER.md
@@ -136,14 +136,14 @@ docker run -it emqtt_bench sub --ifaddr 192.168.2.10
 ## One-way SSL Socket
 
 ```sh
-docker run -it emqtt_bench sub -c 100 -i 10 -t bench/%i -p 8883 -S
-docker run -it emqtt_bench pub -c 100 -I 10 -t bench/%i -p 8883 -s 256 -S
+docker run -it emqtt_bench sub -c 100 -i 10 -t bench/%i -p 8883 --ssl
+docker run -it emqtt_bench pub -c 100 -I 10 -t bench/%i -p 8883 -s 256 --ssl
 ```
 
 ## Two-way SSL Socket
 ```sh
-docker run -it emqtt_bench sub -c 100 -i 10 -t bench/%i -p 8883 --certfile path/to/client-cert.pem --keyfile path/to/client-key.pem
-docker run -it emqtt_bench pub -c 100 -i 10 -t bench/%i -s 256 -p 8883 --certfile path/to/client-cert.pem --keyfile path/to/client-key.pem
+docker run -it emqtt_bench sub -c 100 -i 10 -t bench/%i -p 8883 --ssl --certfile path/to/client-cert.pem --keyfile path/to/client-key.pem
+docker run -it emqtt_bench pub -c 100 -i 10 -t bench/%i -s 256 -p 8883 --ssl --certfile path/to/client-cert.pem --keyfile path/to/client-key.pem
 ```
 
 ## Notice


### PR DESCRIPTION
always provide --ssl option when TLS is in use