### PR TITLE
fix: change --inflight option default value to 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _build/
 /emqtt_bench
 libquicer_nif.so
 rebar3
+*.crashdump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.5
 
-* Default value for `--interval` option is changed from `0` (no back-pressure) to `1`.
+* Default value for `--inflight` option is changed from `0` (no back-pressure) to `1`.
   i.e. `max-inflight` is `1` by default for QoS 1 and 2 messages.
 
 ## 0.4.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,31 @@
+# emqtt-bench changelog
 
-0.4 (2019-07-29)
-----------------
+## 0.4.5
+
+* Default value for `--interval` option is changed from `0` (no back-pressure) to `1`.
+  i.e. `max-inflight` is `1` by default for QoS 1 and 2 messages.
+
+## 0.4.4
+
+Main changes comparing to 0.4.0
+
+* Release on otp 24.2.1
+* Multiple source IP address support (to get around the 64K source port limit)
+* Reports publisher overrun for QoS 1 (when the ack is received after the interval set by `--interval_of_msg` option)
+
+## 0.4 (2019-07-29)
 
 Use the new Erlang MQTT v5.0 client
 
-0.3 (2016-01-29)
-----------------
+## 0.3 (2016-01-29)
 
 emqtt_bench_sub: support to subscribe mutiple topics (#9)
 
-0.2 (2015-10-08)
-----------------
+## 0.2 (2015-10-08)
 
 emqtt_bench_pub, emqtt_bench_sub scripts
 
-0.1 (2015-04-23)
-----------------
+## 0.1 (2015-04-23)
 
 first public release
 

--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -82,7 +82,7 @@
          {shortids, $s, "shortids", {boolean, false},
           "use short ids for client ids"},
          {lowmem, $l, "lowmem", boolean, "enable low mem mode, but use more CPU"},
-         {inflight, $F,"inflight", {integer, 0},
+         {inflight, $F,"inflight", {integer, 1},
           "maximum inflight messages for QoS 1 an 2, value 0 for 'infinity'"}
         ]).
 


### PR DESCRIPTION
The old default value `0` means `infinity`.
Which means no back-pressure from the target MQTT broker under test.

With default set to 1, for each publisher client, only one message
Is put to the send buffer each time.

In conjunction with the `--interval_of_msg` option,
the 'overrun' counter report should indicate if the system
under test is overloaded or not.