### PR TITLE
feat: add mode to distribution name

### DIFF
--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -279,7 +279,7 @@ main(conn, Opts) ->
     start(conn, Opts).
 
 start(PubSub, Opts) ->
-    prepare(Opts), init(),
+    prepare(PubSub, Opts), init(),
     IfAddr = proplists:get_value(ifaddr, Opts),
     AddrList = case IfAddr =/= undefined andalso lists:member($,, IfAddr) of
                     false ->
@@ -309,9 +309,15 @@ start(PubSub, Opts) ->
     timer:send_interval(1000, stats),
     main_loop(os:timestamp(), _Count = 0).
 
-prepare(Opts) ->
-    Sname = list_to_atom(lists:flatten(io_lib:format("~p-~p", [?MODULE, rand:uniform(1000)]))),
-    proplists:get_bool(dist, Opts) andalso net_kernel:start([Sname, shortnames]),
+prepare(PubSub, Opts) ->
+    Sname = list_to_atom(lists:flatten(io_lib:format("~p-~p-~p", [?MODULE, PubSub, rand:uniform(1000)]))),
+    case proplists:get_bool(dist, Opts) of
+        true ->
+            net_kernel:start([Sname, shortnames]),
+            io:format("Starting distribution with name ~p~n", [Sname]);
+        false ->
+            ok
+    end,
     case proplists:get_bool(quic, Opts) of
         true -> maybe_start_quicer() orelse error({quic, not_supp_or_disabled});
         _ ->


### PR DESCRIPTION
This facilitates finding the correct process and distribution port
when using more than one type of bench in the same machine.