### PR TITLE
chore: allow user to override rebar version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,8 @@ release: compile
 	$(REBAR) as emqtt_bench tar
 	@$(CURDIR)/scripts/rename-package.sh
 
-compile: $(REBAR) unlock
+compile: $(REBAR)
 	$(REBAR) compile
-
-.PHONY: unlock
-unlock:
-	$(REBAR) unlock
 
 .PHONY: clean
 clean: distclean

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-REBAR = $(CURDIR)/rebar3
-REBAR_VERSION = 3.14.3-emqx-7
+REBAR ?= $(CURDIR)/rebar3
+REBAR_VERSION ?= 3.14.3-emqx-7
 
 .PHONY: all
 all: release
@@ -32,6 +32,6 @@ docker:
 
 .PHONY: ensure-rebar3
 ensure-rebar3:
-	@$(CURDIR)/scripts/ensure-rebar3.sh $(REBAR_VERSION)
+	$(CURDIR)/scripts/ensure-rebar3.sh $(REBAR_VERSION)
 
 $(REBAR): ensure-rebar3

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -27,9 +27,9 @@ Profiles = {profiles,[ {escript, []}
                                                                 , cowlib
                                                                   | [ quicer || IsQuicSupp ]
                                                                 ] }
-                                , {overlay_vars,[ {runner_root_dir, "$(cd $(dirname $(readlink $0 || echo $0))/..; pwd -P)"}
-                                                , {runner_escript_dir, "$RUNNER_ROOT_DIR/escript"}
-                                                ]}
+                                , {overlay_vars_values, [ {runner_root_dir, "$(cd $(dirname $(readlink $0 || echo $0))/..; pwd -P)"}
+                                                        , {runner_escript_dir, "$RUNNER_ROOT_DIR/escript"}
+                                                        ]}
                                 , {overlay, [ {mkdir, "bin"}
                                             , {mkdir, "escript"}
                                             , {copy, "_build/emqtt_bench/bin", "escript"}


### PR DESCRIPTION
This allow building emqx/emqx-builder#64 successfully under OTP-25 & rebar3 3.19.x.

EMQX-8426