### PR TITLE
ci: release packages for ubuntu22.04, debian11 and el9

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            FROM=ghcr.io/emqx/emqx-builder/5.0-29:${{ matrix.elixir }}-${{ matrix.otp }}-alpine3.15.1
+            FROM=ghcr.io/emqx/emqx-builder/5.0-29:${{ matrix.elixir }}-${{ matrix.otp }}-debian11
 
   linux:
     runs-on: ubuntu-latest
@@ -124,8 +124,6 @@ jobs:
           kerl install ${{ matrix.otp }} $HOME/.kerl/${{ matrix.otp }}
       - name: Make
         shell: bash
-        env:
-          BUILD_WITHOUT_QUIC: 1
         run: |
           . $HOME/.kerl/${{ matrix.otp }}/activate
           make

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,6 +80,7 @@ jobs:
       - shell: bash
         run: |
           [ "false" == ${{ matrix.quic_support }} ] && export BUILD_WITHOUT_QUIC=1
+          git config --global --add safe.directory /__w/emqtt-bench/emqtt-bench
           make
       - if: failure()
         run: cat rebar3.crashdump

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,11 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-          - "24.3.4.2-1"
+          - "24.3.4.2-2"
         elixir:
           - "1.13.4"
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - uses: docker/metadata-action@v4
@@ -42,7 +44,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            FROM=ghcr.io/emqx/emqx-builder/5.0-27:${{ matrix.elixir }}-${{ matrix.otp }}-alpine3.15.1
+            FROM=ghcr.io/emqx/emqx-builder/5.0-29:${{ matrix.elixir }}-${{ matrix.otp }}-alpine3.15.1
 
   linux:
     runs-on: ubuntu-latest
@@ -50,26 +52,31 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-          - "24.3.4.2-1"
+          - "24.3.4.2-2"
         elixir:
           - "1.13.4"
         quic_support:
           - true
           - false
         os:
+          - ubuntu22.04
           - ubuntu20.04
           - ubuntu18.04
           - ubuntu16.04
+          - debian11
           - debian10
           - debian9
+          - el9
           - el8
           - el7
           - amzn2
     container:
-      image: ghcr.io/emqx/emqx-builder/5.0-27:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
+      image: ghcr.io/emqx/emqx-builder/5.0-29:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - shell: bash
         run: |
           [ "false" == ${{ matrix.quic_support }} ] && export BUILD_WITHOUT_QUIC=1
@@ -77,7 +84,7 @@ jobs:
       - if: failure()
         run: cat rebar3.crashdump
       - run: ./_build/emqtt_bench/rel/emqtt_bench/bin/emqtt_bench
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: packages
@@ -91,12 +98,14 @@ jobs:
           - macos-12
           - macos-11
         otp:
-          - "24.3.4.2-1"
+          - "24.3.4.2-2"
 
     runs-on: ${{ matrix.macos }}
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: prepare
         run: |
           brew install curl zip unzip gnu-sed kerl unixodbc freetds
@@ -123,7 +132,7 @@ jobs:
       - if: failure()
         run: cat rebar3.crashdump
       - run: ./_build/emqtt_bench/rel/emqtt_bench/bin/emqtt_bench
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: packages

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,7 +86,6 @@ jobs:
         run: cat rebar3.crashdump
       - run: ./_build/emqtt_bench/rel/emqtt_bench/bin/emqtt_bench
       - uses: actions/upload-artifact@v3
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           name: packages
           path: ./*.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM=ghcr.io/emqx/emqx-builder/5.0-16:1.13.4-24.2.1-1-alpine3.15.1
+ARG FROM=ghcr.io/emqx/emqx-builder/5.0-29:1.13.4-24.3.4.2-2-debian11
 FROM ${FROM}
 COPY . /emqtt_bench
 WORKDIR /emqtt_bench

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
 
 {deps, [
   {getopt, {git, "https://github.com/zmstone/getopt", {tag, "v1.0.2.1"}}},
-  {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.6.1"}}}
+  {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.8.2"}}}
 ]}.
 
 {escript_name, emqtt_bench}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -11,7 +11,7 @@ IsWin32 = fun() ->
                 win32 =:= element(1, os:type())
           end,
 
-Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.16"}}},
+Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.111"}}},
 
 IsQuicSupp = not (IsCentos6() orelse IsWin32() orelse
                   false =/= os:getenv("BUILD_WITHOUT_QUIC")


### PR DESCRIPTION
- actions/checkout@v3 uses sparse checkout by default and rebar fails to detect version correctly
- actions/upload-artifact@v2 fails to detect amazon linux