### PR TITLE
fix: badarg error when publish unicode payloads

### DIFF
--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -326,7 +326,7 @@ main(pub, Opts) ->
                     {ok, Bin} = file:read_file(Path),
                     {template, Bin};
                   StrPayload ->
-                    StrPayload
+                    unicode:characters_to_binary(StrPayload)
               end,
     MsgLimit = consumer_pub_msg_fun_init(proplists:get_value(limit, Opts)),
     PublishSignalPid =


### PR DESCRIPTION
./bin/emqtt_bench pub --host 116.204.79.214 -p 1883 -t /ys/access/rule/Y000c57ffd9b-1049644423035486208 -c 1 -I 10000 -m $(cat mqtt-p/29-03-2023_16_54_42.60882508.bin)

And the `mqtt-p/29-03-2023_16_54_42.60882508.bin` contains some unicode characters, the emqtt_bench pub fails with the following error:

```
=ERROR REPORT==== 29-Mar-2023::18:24:17.778134 ===
Error in process <0.120.0> with exit value:
{badarg,[{erlang,iolist_to_binary,
                 [[123,34,20445,25252,67,30456,30005,27969,34,58,123,34,116,
                   115,34,58,34,49,54,56,48,48,56,48,48,56,50,54,49,48,34,44,
                   34,118,97,108,117,101,34,58,50,46,54,50,125,44,34,20445,
                   25252,65,30456,30005,27969,34,58,123,34,116,115,34,58,34,
                   49,54,56,48,48,56,48,48,56,50,54,49,48,34,44,34,118,97,108,
                   117,101,34,58,50,46,52,49,125,44,34,39057,29575,34,58,123,
                   34,116,115,34,58,34,49,54,56,48,48,56,48,48,56,50,54,49,49,
                   34,44,34,118,97,108,117,101,34,58,53,48,46,48,51,125,44,34,
                   66,30456,30005,21387,34,58,123,34,116,115,34,58,34,49,54,
                   56,48,48,56,48,48,56,50,54,51,48,34,44,34,118,97,108,117,
                   101,34,58,53,46,55,55,125,44,34,26080,21151,21151,29575,34,
                   58,123,34,116,115,34,58,34,49,54,56,48,48,55,57,50,54,54,
                   53,57,55,34,44,34,118,97,108,117,101,34,58,48,125,44,34,66,
                   30456,30005,27969,34,58,123,34,116,115,34,58,34,49,54,56,
                   48,48,56,48,48,56,50,54,49,48,34,44,34,118,97,108,117,101,
                   34,58,50,46,52,52,125,44,34,83,121,115,68,101,118,79,110,
                   108,105,110,101,83,116,97,116,101,34,58,123,34,116,115,34,
                   58,34,49,54,56,48,48,54,52,51,48,50,57,52,55,34,44,34,118,
                   97,108,117,101,34,58,116,114,117,101,125,44,34,112,114,111,
                   100,117,99,116,75,101,121,34,58,34,89,48,48,48,99,53,55,
                   102,102,100,57,98,34,44,34,21151,29575,22240,25968,34,58,
                   123,34,116,115,34,58,34,49,54,56,48,48,55,57,50,54,54,54,
                   48,48,34,44,34,118,97,108,117,101,34,58,49,125,44,34,35270,
                   22312,21151,29575,34,58,123,34,116,115,34,58,34,49,54,56,
                   48,48,56,48,48,56,50,54,49,49,34,44,34,118,97,108,117,101,
                   34,58,51,57,46,49,50,125,44,34,38646,24207,30005,21387,34,
                   58,123,34,116,115,34,58,34,49,54,56,48,48,54,52,51,48,50,
                   57,52,55,34,44,34,118,97,108,117,101,34,58,48,125,44,34,
                   20445,25252,66,30456,30005,27969,34,58,123,34,116,115,34,
                   58,34,49,54,56,48,48,56,48,48,56,50,54,49,48,34,44,34,118,
                   97,108,117,101,34,58,50,46,52,125,44,34,67,30456,30005,
                   21387,34,58,123,34,116,115,34,58,34,49,54,56,48,48,56,48,
                   48,56,50,54,49,48,34,44,34,118,97,108,117,101,34,58,53,46,
                   55,54,125,44,34,20445,25252,38646,24207,30005,27969,34,58,
                   123,34,116,115,34,58,34,49,54,56,48,48,54,52,51,48,50,57,
                   52,55,34,44,34,118,97,108,117,101,34,58,48,125,44,34,65,
                   30456,30005,21387,34,58,123,34,116,115,34,58,34,49,54,56,
                   48,48,56,48,48,56,50,54,48,57,34,44,34,118,97,108,117,101,
                   34,58,53,46,54,125,44,34,65,66,32447,30005,21387,34,58,123,
                   34,116,115,34,58,34,49,54,56,48,48,54,52,51,48,50,57,52,55,
                   34,44,34,118,97,108,117,101,34,58,48,125,44,34,26377,21151,
                   21151,29575,34,58,123,34,116,115,34,58,34,49,54,56,48,48,
                   56,48,48,56,50,54,49,49,34,44,34,118,97,108,117,101,34,58,
                   51,57,46,49,50,125,44,34,65,30456,30005,27969,34,58,123,34,
                   116,115,34,58,34,49,54,56,48,48,56,48,48,56,50,54,49,48,34,
                   44,34,118,97,108,117,101,34,58,50,46,52,125,44,34,100,101,
                   118,105,99,101,75,101,121,34,58,34,89,48,48,48,99,53,55,
                   102,102,100,57,98,45,49,48,52,57,54,52,52,52,50,51,48,51,
                   53,52,56,54,50,48,56,34,44,34,67,30456,30005,27969,34,58,
                   123,34,116,115,34,58,34,49,54,56,48,48,56,48,48,56,50,54,
                   49,48,34,44,34,118,97,108,117,101,34,58,50,46,54,53,125,44,
                   34,116,114,105,103,103,101,114,84,121,112,101,34,58,34,68,
                   69,86,73,67,69,95,84,82,73,71,71,69,82,34,44,34,27597,
                   32447,30005,21387,85,99,98,34,58,123,34,116,115,34,58,34,
                   49,54,56,48,48,56,48,48,56,50,54,49,49,34,44,34,118,97,108,
                   117,101,34,58,49,48,125,44,34,66,67,32447,30005,21387,34,
                   58,123,34,116,115,34,58,34,49,54,56,48,48,54,52,51,48,50,
                   57,52,55,34,44,34,118,97,108,117,101,34,58,48,125,44,34,
                   27597,32447,30005,21387,85,97,98,34,58,123,34,116,115,34,
                   58,34,49,54,56,48,48,56,48,48,56,50,54,49,49,34,44,34,118,
                   97,108,117,101,34,58,57,46,56,55,125,44,34,116,115,34,58,
                   49,54,56,48,48,56,48,48,56,51,55,49,49,125]],
                 [{error_info,#{module => erl_erts_errors}}]},
         {emqtt,publish,5,
                [{file,"/Users/liuxy/code/emqtt-bench/_build/default/lib/emqtt/src/emqtt.erl"},
                 {line,388}]},
         {emqtt_bench,publish,2,
                      [{file,"/Users/liuxy/code/emqtt-bench/src/emqtt_bench.erl"},
                       {line,804}]},
         {emqtt_bench,loop,5,
                      [{file,"/Users/liuxy/code/emqtt-bench/src/emqtt_bench.erl"},
                       {line,663}]}]}
```