### PR TITLE
fix: default value of payload_hdrs

### DIFF
--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -687,7 +687,7 @@ loop(Parent, N, Client, PubSub, Opts) ->
             end;
         {publish, #{payload := Payload}} ->
             inc_counter(recv),
-            maybe_check_payload_hdrs(Payload, proplists:get_value(payload_hdrs, Opts)),
+            maybe_check_payload_hdrs(Payload, proplists:get_value(payload_hdrs, Opts, [])),
             loop(Parent, N, Client, PubSub, Opts);
         {'EXIT', _Client, normal} ->
             ok;


### PR DESCRIPTION
when emqtt-bench run with 'conn' command, the default payload_hdrs is unset.
The client may receive pubs due to implicit subscribition