### PR TITLE
ci: bump actions version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,12 +13,12 @@ jobs:
         elixir:
           - 1.15.7
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/metadata-action@v4
+      - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+      - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+      - uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c # v5.5.0
         id: meta
         with:
           images: ${{ github.repository }}
@@ -26,12 +26,12 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         if: startsWith(github.ref, 'refs/tags/') || inputs.publish_release_artifacts
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         with:
           context: .
           platforms: linux/amd64
@@ -60,7 +60,7 @@ jobs:
       image: ghcr.io/emqx/emqx-builder/5.2-7:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
       - shell: bash
@@ -78,9 +78,9 @@ jobs:
           cd test-release
           tar xfz ./emqtt-bench*.tar.gz
           bin/emqtt_bench
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
-          name: packages
+          name: "emqtt-bench-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ matrix.quic_support }}"
           path: ./*.tar.gz
 
   mac:
@@ -97,7 +97,7 @@ jobs:
     runs-on: ${{ matrix.macos }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
       - name: prepare
@@ -105,7 +105,7 @@ jobs:
           brew install curl zip unzip gnu-sed kerl unixodbc freetds
           echo "/usr/local/bin" >> $GITHUB_PATH
           git config --global credential.helper store
-      - uses: actions/cache@v3
+      - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
         id: cache
         with:
           path: ~/.kerl
@@ -145,7 +145,7 @@ jobs:
           cd test-release
           unzip -q ./emqtt-bench*.zip
           bin/emqtt_bench
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
-          name: packages
+          name: "emqtt-bench-${{ matrix.macos }}-${{ matrix.otp }}"
           path: ./*.zip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,8 +89,6 @@ jobs:
       matrix:
         macos:
           - macos-12-arm64
-          - macos-12
-          - macos-13
         otp:
           - 25.3.2-2
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,13 +24,13 @@ jobs:
         elixir:
           - 1.15.7
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ github.event.inputs.branch_or_tag }}
           fetch-depth: 0
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/metadata-action@v4
+      - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+      - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+      - uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c # v5.5.0
         id: meta
         with:
           images: ${{ github.repository }}
@@ -39,12 +39,12 @@ jobs:
             type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         if: github.event_name == 'push' || inputs.publish_release_artifacts
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -69,22 +69,17 @@ jobs:
         os:
           - ubuntu22.04
           - ubuntu20.04
-          - ubuntu18.04
-          - ubuntu16.04
           - debian12
           - debian11
-          - debian10
-          - debian9
           - el9
           - el8
-          - el7
           - amzn2
           - amzn2023
     container:
       image: ghcr.io/emqx/emqx-builder/5.2-7:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch_or_tag }}
@@ -103,9 +98,9 @@ jobs:
           cd test-release
           tar xfz ./emqtt-bench*.tar.gz
           bin/emqtt_bench
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
-          name: packages
+          name: "emqtt-bench-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ matrix.quic_support }}"
           path: ./*.tar.gz
 
   mac:
@@ -122,7 +117,7 @@ jobs:
     runs-on: ${{ matrix.macos }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch_or_tag }}
@@ -131,7 +126,7 @@ jobs:
           brew install curl zip unzip gnu-sed kerl unixodbc freetds
           echo "/usr/local/bin" >> $GITHUB_PATH
           git config --global credential.helper store
-      - uses: actions/cache@v3
+      - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
         id: cache
         with:
           path: ~/.kerl
@@ -171,9 +166,9 @@ jobs:
           cd test-release
           unzip -q ./emqtt-bench*.zip
           bin/emqtt_bench
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
-          name: packages
+          name: "emqtt-bench-${{ matrix.otp }}-${{ matrix.macos }}"
           path: ./*.zip
 
   release:
@@ -184,12 +179,13 @@ jobs:
     if: github.event_name == 'push' || inputs.publish_release_artifacts
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
-          name: packages
+          pattern: "emqtt-bench-*"
           path: packages
+          merge-multiple: true
       - name: Create Release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -203,7 +199,7 @@ jobs:
           repo: emqtt-bench
           path: "packages/emqtt-bench-*"
           token: ${{ github.token }}
-      - uses: aws-actions/configure-aws-credentials@v1-node16
+      - uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
also stop releasing packages for older platforms:
- Ubuntu 16.04
- Ubuntu 18.04
- Debian 9
- Debian 10
- RHEL 7