### PR TITLE
fix: ifaddr sharding does not work

### DIFF
--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -623,8 +623,8 @@ run(Parent, I, N, PubSub, Opts0, AddrList, HostList) ->
                         []
                 end,
 
-    Opts1 = replace_opts(Opts0, [ {ifaddr, shard_addr(N, AddrList)}
-                                , {host, shard_addr(N, HostList)}
+    Opts1 = replace_opts(Opts0, [ {ifaddr, shard_addr(I, AddrList)}
+                                , {host, shard_addr(I, HostList)}
                                 ]),
     %% only the last one can send the 'go' signal
     Opts = [{send_go_signal, I + 1 =:= N} | Opts1],


### PR DESCRIPTION
The following command line will ways use `192.168.150.25` as source IP address:

```
./bin/emqtt_bench conn -p 1883 -i 10 -c 50 --ifaddr "192.168.150.25,127.0.0.1"
```
