### PR TITLE
fix(build): escript_incl_apps in rebar.config.script

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,6 @@
 
 {escript_name, emqtt_bench}.
 {escript_main_app, emqtt_bench}.
-{escript_incl_apps, [prometheus, quantile_estimator, cowboy]}.
 {escript_emu_args, "%%! -smp true +K true +A 16 +P 16000000 +Muacnl 0 +hms 64 -env ERL_MAX_PORTS 16000000 -env ERTS_MAX_PORTS 16000000\n"}.
 {escript_shebang, "#!/usr/bin/env escript\n"}.
 {provider_hooks, [{post, [{compile, escriptize}]}]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -57,8 +57,11 @@ ExtraDeps = fun(C) ->
             end,
 
 NewConfig = [ {escript_incl_apps, 
-               [emqtt_bench | 
-                [ quicer || IsQuicSupp ]
+               [emqtt_bench,
+                prometheus, 
+                quantile_estimator,
+                cowboy
+               | [ quicer || IsQuicSupp ]
                ]}
             , Profiles
             | ExtraDeps(CONFIG)],


### PR DESCRIPTION
The quicer app is dynamically added to the escript according to the BUILD_WITHOUT_QUIC Flag, so this must be done in rebar.config.script