### PR TITLE
fix: upgrade to emqtt 1.13.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,16 @@ REBAR ?= $(CURDIR)/rebar3
 .PHONY: all
 all: release
 
+.PHONY: release
 release: compile
 	$(REBAR) as emqtt_bench tar
 	@$(CURDIR)/scripts/rename-package.sh
 
+.PHONY: pre-release
+pre-release: compile
+	$(REBAR) as emqtt_bench release
+
+.PHONY: compile
 compile: $(REBAR)
 	$(REBAR) compile
 

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
 
 {deps, [
   {getopt, {git, "https://github.com/zmstone/getopt", {tag, "v1.0.2.1"}}},
-  {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.2"}}},
+  {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.4"}}},
   {prometheus, {git, "https://github.com/emqx/prometheus.erl", {tag, "v4.10.0.2"}}},
   {cowboy, "2.9.0"},
   {jsx, "3.1.0"}


### PR DESCRIPTION
emqtt 1.13.4 has reconnect fixed
now bench clients should experience less shutdowns when testing with higher connection rate than the target broker allows.

when test against emqx with `max_conn_rate` set to `10`

```
> ./_build/emqtt_bench/rel/emqtt_bench/bin/emqtt_bench conn -h localhost -p 1883 -c 1000 --reconnect 100000
Start with 20 workers, addrs pool size: 1 and req interval: 200 ms

1s connect_succ total=18 rate=17.96/sec
2s connect_succ total=28 rate=10.00/sec
3s connect_succ total=38 rate=10.00/sec
4s connect_succ total=48 rate=10.00/sec
5s connect_succ total=57 rate=9.00/sec
6s connect_succ total=67 rate=10.00/sec
7s connect_succ total=77 rate=10.00/sec
8s connect_succ total=87 rate=10.00/sec
9s connect_succ total=97 rate=10.00/sec
10s connect_succ total=107 rate=10.00/sec
11s connect_succ total=117 rate=10.00/sec
12s connect_succ total=127 rate=10.00/sec
13s connect_succ total=137 rate=10.00/sec
14s connect_succ total=147 rate=10.00/sec
15s connect_succ total=157 rate=10.00/sec
```