### PR TITLE
perf: hibernate main loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ libquicer_nif.so
 rebar3
 *.crashdump
 _checkouts/
+.envrc
+erlang_ls.config

--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -27,6 +27,9 @@
         , loop/5
         ]).
 
+%% Internal callback
+-export([wakeup_main_loop/2, main_loop/2]).
+
 -define(STARTNUMBER_DESC,
         "The start point when assigning sequence numbers to clients. "
         "This is useful when running multiple emqtt-bench "
@@ -502,11 +505,19 @@ main_loop(Uptime, Count) ->
             maybe_print_qoe(Count),
             maybe_dump_nst_dets(Count),
             garbage_collect(),
-            main_loop(Uptime, Count);
+            hibernate_main_loop(Uptime, Count);
         Msg ->
             print("main_loop_msg: ~p~n", [Msg]),
-            main_loop(Uptime, Count)
+            hibernate_main_loop(Uptime, Count)
+    after 5 ->
+        hibernate_main_loop(Uptime, Count)
     end.
+
+hibernate_main_loop(Uptime, Count) ->
+    proc_lib:hibernate(?MODULE, wakeup_main_loop, [Uptime, Count]).
+
+wakeup_main_loop(Uptime, Count) ->
+    ?MODULE:main_loop(Uptime, Count).
 
 maybe_dump_nst_dets(Count)->
     Count == ets:info(quic_clients_nsts, size)
@@ -743,7 +754,6 @@ maybe_retry(Parent, N, PubSub, Opts, ContinueFn) ->
 loop(Parent, N, Client, PubSub, Opts) ->
     Interval = proplists:get_value(interval_of_msg, Opts, 0),
     Prometheus = lists:member(prometheus, Opts),
-    Idle = max(Interval * 2, 500),
     MRef = proplists:get_value(publish_signal_mref, Opts),
     receive
         {'DOWN', MRef, process, _Pid, start_publishing} ->
@@ -818,7 +828,7 @@ loop(Parent, N, Client, PubSub, Opts) ->
             io:format("client(~w): discarded unknown message ~p~n", [N, Other]),
             loop(Parent, N, Client, PubSub, Opts)
     after
-        Idle ->
+        _Idle = max(Interval * 2, 50) ->
             case proplists:get_bool(lowmem, Opts) of
                 true ->
                     erlang:garbage_collect(Client, [{type, major}]),


### PR DESCRIPTION
Compared `0.4.26` and this branch with same benchmark command
(both using docker image local built by command `make docker`)

bench compose file:

<details>
Connecting to a 2-nodes-cluster

```yaml
services:

  node1-bench1:
    image: emqx/emqtt_bench:${EMQTT_BENCH_TAG}
    restart: always
    container_name: node1-bench1
    command: "conn -i 2 -h 172.19.0.2 -u admin -P public123 -c ${BENCH_CONN_COUNT_PER_NODE:-25000} --prefix node1-bench1"
    hostname: node1-bench1
    networks:
      emqx-net:
        ipv4_address: 172.19.0.31

  node1-bench2:
    image: emqx/emqtt_bench:${EMQTT_BENCH_TAG}
    restart: always
    container_name: node1-bench2
    command: "conn -i 2 -h 172.19.0.2 -u admin -P public123 -c ${BENCH_CONN_COUNT_PER_NODE:-25000} --prefix node1-bench2"
    hostname: node1-bench2
    networks:
      emqx-net:
        ipv4_address: 172.19.0.32

  node2-bench1:
    image: emqx/emqtt_bench:${EMQTT_BENCH_TAG}
    restart: always
    container_name: node2-bench1
    command: "conn -i 2 -h 172.19.0.3 -u admin -P public123 -c ${BENCH_CONN_COUNT_PER_NODE:-25000} --prefix node2-bench1"
    hostname: node2-bench1
    networks:
      emqx-net:
        ipv4_address: 172.19.0.33

  node2-bench2:
    image: emqx/emqtt_bench:${EMQTT_BENCH_TAG}
    restart: always
    container_name: node2-bench2
    command: "conn -i 2 -h 172.19.0.3 -u admin -P public123 -c ${BENCH_CONN_COUNT_PER_NODE:-25000} --prefix node2-bench2"
    hostname: node2-bench2
    networks:
      emqx-net:
        ipv4_address: 172.19.0.34

networks:
  emqx-net:
    ipam:
      config:
        - subnet: 172.19.0.0/16
    driver: bridge
```

</details>

CPU usage when the number of connections is about 14,000, (about 20 seconds after starting)


`0.4.26`:
![image](https://github.com/user-attachments/assets/f869bac7-57a8-4074-a688-f3e3bab7620e)


this branch: 
![image](https://github.com/user-attachments/assets/95e9e3b2-094b-40a3-be89-5885aba37269)
