### PR TITLE
Always release quic supported version for now

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,6 @@ jobs:
           - 1.15.7
         quic_support:
           - true
-          - false
         os:
           - ubuntu22.04
           - ubuntu20.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # emqtt-bench changelog
 
+## 0.4.27
+
+* Add bench `cacertfile` option for completeness.
+
 ## 0.4.26
 
 * Upgrade emqtt to 1.13.4 so initial CONNECT packet send failures will not cause client to shutdown/crash.


### PR DESCRIPTION
quick_support=false caused some troubles: https://github.com/emqx/emqtt-bench/actions/runs/12316275289
