### PR TITLE
fix: oom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # emqtt-bench changelog
 
+## 0.4.28
+
+* Fix OOM issue.
+
 ## 0.4.27
 
 * Add bench `cacertfile` option for completeness.

--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -645,7 +645,7 @@ run(Parent, I, N, PubSub, Opts0, AddrList, HostList) ->
     ID = I + 1 + proplists:get_value(startnumber, Opts),
     spawn_opt(?MODULE, connect, [Parent, ID, PubSub, Opts], SpawnOpts),
     timer:sleep(proplists:get_value(interval, Opts)),
-    run(Parent, I + 1, N, PubSub, Opts, AddrList, HostList).
+    run(Parent, I + 1, N, PubSub, Opts0, AddrList, HostList).
 
 connect(Parent, N, PubSub, Opts) ->
     process_flag(trap_exit, true),


### PR DESCRIPTION
Prior to this fix, the `Opts` arg continues to grow.
It may also attribute to higher CPU utilization.