### PR TITLE
more functions for QoE tracking

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-          - 26.2.5-1
+          - 26.2.5.2-3
         elixir:
           - 1.15.7
         quic_support:
@@ -72,6 +72,7 @@ jobs:
           - debian11
           - el9
           - el8
+          - el7
           - amzn2
           - amzn2023
         arch:
@@ -79,7 +80,7 @@ jobs:
           - "-arm"
     runs-on: ubuntu-22.04${{ matrix.arch }}
     env:
-      IMAGE: ghcr.io/emqx/emqx-builder/5.3-7:1.15.7-${{ matrix.otp }}-${{ matrix.os }}
+      IMAGE: ghcr.io/emqx/emqx-builder/5.4-4:1.15.7-${{ matrix.otp }}-${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,6 @@ jobs:
             FROM=ghcr.io/emqx/emqx-builder/5.3-7:${{ matrix.elixir }}-${{ matrix.otp }}-debian12
 
   linux:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -75,6 +74,10 @@ jobs:
           - el8
           - amzn2
           - amzn2023
+        arch:
+          - ""
+          - "-arm"
+    runs-on: ubuntu-22.04${{ matrix.arch }}
     env:
       IMAGE: ghcr.io/emqx/emqx-builder/5.3-7:1.15.7-${{ matrix.otp }}-${{ matrix.os }}
 
@@ -114,7 +117,7 @@ jobs:
           popd
       - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
-          name: "emqtt-bench-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ matrix.quic_support }}"
+          name: "emqtt-bench-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ matrix.quic_support }}${{ matrix.arch }}"
           path: ./*.tar.gz
 
   mac:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # emqtt-bench changelog
 
 ## 0.4.31
-* (Breaking Change) cmdline arg `-S --ssl` now requires one more argument, see below
-* Support `-S tlsv1.3` to enforce TLS version. 
+* New `--ssl-version` to enforce TLS version and implies ssl is enabled.
 * QoE logging now logs TCP handshake latency during TLS handshake ( emqtt 1.14.0).
 * QoE logging now logs each publish msg' end to end latency if `--payload-hdrs=ts` is set by both subscriber and publisher. 
 * Dump TLS secrets per connecion to SSLKEYLOGFILE specifed by envvar SSLKEYLOGFILE for TLS traffic decryption.  (TLS and QUIC)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # emqtt-bench changelog
 
+## 0.4.31
+* (Breaking Change) cmdline arg `-S --ssl` now requires one more argument, see below
+* Support `-S tlsv1.3` to enforce TLS version. 
+* QoE logging now logs TCP handshake latency during TLS handshake ( emqtt 1.14.0).
+* QoE logging now logs each publish msg' end to end latency if `--payload-hdrs=ts` is set by both subscriber and publisher. 
+* Dump TLS secrets per connecion to SSLKEYLOGFILE specifed by envvar SSLKEYLOGFILE for TLS traffic decryption.  (TLS and QUIC)
+* Now build release for arm64.
+* Now build release for el7 with newer build image.
+
 ## 0.4.30
 
 * Enhanced QoE trackings, add supports for commands `conn` and `pub`.

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
 
 {deps, [
   {getopt, {git, "https://github.com/zmstone/getopt", {tag, "v1.0.2.1"}}},
-  {emqtt, {git, "https://github.com/emqx/emqtt", {branch, "dev/william/qoe-tls-tcp-hs-latency"}}},
+  {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.0"}}},
   {prometheus, {git, "https://github.com/emqx/prometheus.erl", {tag, "v4.10.0.2"}}},
   {cowboy, "2.9.0"},
   {jsx, "3.1.0"}

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
 
 {deps, [
   {getopt, {git, "https://github.com/zmstone/getopt", {tag, "v1.0.2.1"}}},
-  {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.4"}}},
+  {emqtt, {git, "https://github.com/emqx/emqtt", {branch, "dev/william/qoe-tls-tcp-hs-latency"}}},
   {prometheus, {git, "https://github.com/emqx/prometheus.erl", {tag, "v4.10.0.2"}}},
   {cowboy, "2.9.0"},
   {jsx, "3.1.0"}

--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -181,7 +181,7 @@
           "Handle the payload header from received message. "
           "Publish side must have the same option enabled in the same order. "
           "cnt64: Check the counter is strictly increasing. "
-          "ts: publish latency counting."
+          "ts: publish latency counting, could be used for QoE tracking as well"
          },
          {qos, $q, "qos", {integer, 0},
           "subscribe qos"}

--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -166,7 +166,7 @@
          {min_random_wait, undefined,"min-random-wait", {integer, 0},
           "minimum randomized period in ms that each publisher will wait before "
           "starting to publish (uniform distribution)"},
-         {retry_interval, 0, "retry-interval", {integer, 0},
+         {retry_interval, undefined, "retry-interval", {integer, 0},
           "Publisher's resend interval (in seconds) if the expected "
           "acknowledgement for a inflight packet is not "
           "received within this interval. Default value 0 means no resend."

--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -913,8 +913,9 @@ mqtt_opts([{ssl, Bool}|Opts], Acc) when is_boolean(Bool) ->
 mqtt_opts([{ssl, Ver}|Opts], Acc) when Ver == tlsv1;
                                        Ver == 'tlsv1.1';
                                        Ver == 'tlsv1.2';
+                                       Ver == 'tlsv1.3_nocompat';
                                        Ver == 'tlsv1.3' ->
-    mqtt_opts(Opts, [{ssl, true}, {ssl_versions, [Ver]}|Acc]);
+    mqtt_opts(Opts, [{ssl, true} | Acc]);
 mqtt_opts([{lowmem, Bool}|Opts], Acc) ->
     mqtt_opts(Opts, [{low_mem, Bool} | Acc]);
 mqtt_opts([{qoe, Bool}|Opts], Acc) ->
@@ -960,8 +961,12 @@ ssl_opts([{certfile, CertFile} | Opts], Acc) ->
     ssl_opts(Opts, [{certfile, CertFile}|Acc]);
 ssl_opts([{cacertfile, CaCertFile} | Opts], Acc) ->
     ssl_opts(Opts, [{cacertfile, CaCertFile}|Acc]);
-ssl_opts([{ssl_versions, Vsns} | Opts], Acc) ->
-    ssl_opts(Opts, [{versions, Vsns}|Acc]);
+ssl_opts([{ssl, 'tlsv1.3_nocompat'} | Opts], Acc) ->
+    ssl_opts(Opts, [{versions, ['tlsv1.3']}, {middlebox_comp_mode, false} | Acc]);
+ssl_opts([{ssl, IsSSL} | Opts], Acc) when is_boolean(IsSSL) ->
+    ssl_opts(Opts, Acc);
+ssl_opts([{ssl, Vsn} | Opts], Acc) ->
+    ssl_opts(Opts, [{versions, [Vsn]} | Acc]);
 ssl_opts([{nst_dets_file, DetsFile}| Opts], Acc) ->
     ok = prepare_nst(DetsFile),
     io:format("enable session_tickets~n"),

--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -75,7 +75,7 @@
           "max retries of reconnects. 0: disabled"},
          %% == Transport: TCP, TLS, QUIC, WS ==
          {ssl, $S, "ssl", {atom, false},
-          "ssl socket for connecting to server"},
+          "enable TLS/SSL transport: true | false | 'tlsv1.1' | 'tlsv1.2' | 'tlsv1.3' | 'tlsv1.3_nocompat'"},
          {cacertfile, undefined, "cacertfile", string,
           "CA certificate for server verification"},
          {certfile, undefined, "certfile", string,


### PR DESCRIPTION
* ~~(Breaking Change) cmdline arg `-S --ssl` now requires one more argument, see below~~
 * Support `--ssl-version tlsv1.3` to enforce TLS version. 
 * QoE logging now logs TCP handshake latency during TLS handshake ( emqtt 1.14.0).
 * QoE logging now logs each publish msg' end to end latency if `--payload-hdrs=ts` is set by both subscriber and publisher. 
 * Dump TLS secrets per connecion to SSLKEYLOGFILE specifed by envvar SSLKEYLOGFILE for TLS traffic decryption.  (TLS and QUIC)
 * Now build release for arm64.
 * Now build release for el7 with newer build image.