### PR TITLE
fix(qoe): csv dump invalid_elapsed to ""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # emqtt-bench changelog
 
+## 0.4.32
+
+* QoE: Fix csv dump, represent `invalid_elapsed` as `""` instead of `-1` 
+
 ## 0.4.31
+
 * New `--ssl-version` to enforce TLS version and implies ssl is enabled.
 * QoE logging now logs TCP handshake latency during TLS handshake ( emqtt 1.14.0).
 * QoE logging now logs each publish msg' end to end latency if `--payload-hdrs=ts` is set by both subscriber and publisher. 


### PR DESCRIPTION
`invalid_elapsed` mean n/a value.

we used to present invalid_elapsed to -1 in CSV dump. then the mqtt.publish e2e latency became confusion because in case the test machines(pub machine, sub machine) are not time synced, we could get <0 latency.

Now we present `invalid_elapsed` to "" and should no longer confusion.