### PR TITLE
feat: support TLS --ciphers and --signature_algs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.4.32
 
-* QoE: Fix csv dump, represent `invalid_elapsed` as `""` instead of `-1` 
+* QoE: Fix csv dump, represent `invalid_elapsed` as `""` instead of `-1`
+* TLS: support `--ciphers` and `--signature-algs`
 
 ## 0.4.31
 


### PR DESCRIPTION
add two new opts for TLS tests

--ciphers
--signature_algs