### PR TITLE
Fix/william/sslkeylogfile tcp crash 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,7 @@ jobs:
           brew install curl zip unzip gnu-sed kerl unixodbc freetds
           echo "/usr/local/bin" >> $GITHUB_PATH
           git config --global credential.helper store
-      - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ~/.kerl

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -143,7 +143,7 @@ jobs:
           brew install curl zip unzip gnu-sed kerl unixodbc freetds
           echo "/usr/local/bin" >> $GITHUB_PATH
           git config --global credential.helper store
-      - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ~/.kerl

--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -994,10 +994,8 @@ ssl_opts([{sslversion, Vsn} | Opts], Acc) ->
     ssl_opts(Opts, [{versions, [Vsn]} | Acc]);
 ssl_opts([{ssl, IsSSL} | Opts], Acc) when is_boolean(IsSSL) ->
     ssl_opts(Opts, Acc);
-ssl_opts([{nst_dets_file, DetsFile}| Opts], Acc) ->
-    ok = prepare_nst(DetsFile),
-    io:format("enable session_tickets~n"),
-    ssl_opts(Opts, [{session_tickets, manual}|Acc]);
+ssl_opts([{nst_dets_file, _DetsFile}| Opts], Acc) ->
+    ssl_opts(Opts, [{session_tickets, manual} | Acc]);
 ssl_opts([{ciphers, Ciphers}| Opts], Acc) ->
     CipherList = [ssl:str_to_suite(X) || X <- string:tokens(Ciphers, ",")],
     ssl_opts(Opts, [{ciphers, CipherList} | Acc]);


### PR DESCRIPTION
- Fix crash in tcp transport when SSLKEYLOGFILE env is set.
- Remove dummy prepare nst call while handling ssl opts.