### PR TITLE
ci: stop building packages for obsolete platforms

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,13 +68,10 @@ jobs:
         os:
           - ubuntu24.04
           - ubuntu22.04
-          - ubuntu20.04
+          - debian13
           - debian12
-          - debian11
           - el9
           - el8
-          - el7
-          - amzn2
           - amzn2023
         arch:
           - amd64


### PR DESCRIPTION
disable el7, amzn2, debian11 and ubuntu20.04
add debian13