### PR TITLE
fix: reason code mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # emqtt-bench changelog
 
+## 0.6.2
+
+- Fix unknown message `{publish_async_res, ...` when `--topics-payload` is in use.
+
 ## 0.6.1
 
 - Report `PUBACK` failure counters. Reason code 0x10 (16) is recorded as `pub_nosub` and other reason codes are recorded as `pub_fail`.

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ e.g. `emqtt-bench-0.6.0-ubuntu24.04-arm64-quic.tar.gz`
 1. After untar, execute the `emqtt_bench` with additional environment variables.
 
 ``` sh
-ERL_MAX_PORTS=1024  ERL_FLAGS="+P 1024" bin/emqtt_bench pub -t /from/rpi3 -s 2048 -q 1 -I 2000
+ERL_ZFLAGS="+P 1024 -env ERL_MAX_PORTS 1024" bin/emqtt_bench pub -t /from/rpi3 -s 2048 -q 1 -I 2000
 ```
 
 

--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -736,13 +736,13 @@ loop(Parent, N, Client, PubSub, Opts) ->
        {publish_async_res, ok} ->
           inc_counter(Prometheus, pub),
           loop(Parent, N, Client, PubSub, Opts);
-       {publish_async_res, {ok, #{reason := ?RC_NO_MATCHING_SUBSCRIBERS}}} ->
+       {publish_async_res, {ok, #{reason_code := ?RC_NO_MATCHING_SUBSCRIBERS}}} ->
           inc_counter(Prometheus, pub_nosub),
           loop(Parent, N, Client, PubSub, Opts);
-       {publish_async_res, {ok, #{reason := ?RC_SUCCESS}}} ->
+       {publish_async_res, {ok, #{reason_code := ?RC_SUCCESS}}} ->
           inc_counter(Prometheus, pub_succ),
           loop(Parent, N, Client, PubSub, Opts);
-       {publish_async_res, {ok, #{reason := _}}} ->
+       {publish_async_res, {ok, #{reason_code := _}}} ->
           inc_counter(Prometheus, pub_fail),
           loop(Parent, N, Client, PubSub, Opts);
        {publish_async_res, {error, _}} ->

--- a/topic_spec.json
+++ b/topic_spec.json
@@ -9,7 +9,7 @@
          "payload": {"foo1" : "bar1", "timestamp": "0", "Data": "%p10"},
          "stream" : 0,
          "stream_priority": 200,
-         "render": "Data",
+         "render": "Data"
         },
 
         {"name": "Topic2/%i",
@@ -20,7 +20,7 @@
          "payload": {"foo2" : "bar2", "timestamp": "0", "VIN" : "VIN", "Data": "%p2500"},
          "stream" : 0,
          "stream_priority": 8,
-         "render": "Data",
+         "render": "Data"
         }
     ]
 }


### PR DESCRIPTION
1. Fix reason code match 
```
./emqtt_bench pub -t a  --topics-payload ./topic_spec.json

....
client(147): discarded unknown message {publish_async_res,
                                        {ok,
                                         #{via => #Port<0.153>,
                                           reason_code_name =>
                                            no_matching_subscribers,
                                           reason_code => 16,
                                           properties => #{},
                                           packet_id => 16}}}
```


2. Fix ./topic_spec.json file that cannot be parsed by OTP json.