### PR TITLE
bump emqtt 1.15.1 and add new arg: `active`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # emqtt-bench changelog
 
+## 0.6.3
+
+- New Option `--active` for fine tune client erlang ports.
+- Bump rebar3 to 3.24.0-emqx-1
+- Fix macOS release
+
 ## 0.6.2
 
 - Fix unknown message `{publish_async_res, ...` when `--topics-payload` is in use.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ all: release
 .PHONY: release
 release: compile
 	$(REBAR) as emqtt_bench tar
+	@$(CURDIR)/scripts/macos-sign-binaries.sh
+	@$(CURDIR)/scripts/macos-notarize-package.sh
 	@$(CURDIR)/scripts/rename-package.sh
 
 .PHONY: pre-release

--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
   {getopt, "1.0.2"},
   {cowlib, "2.15.0"},
   {gun, "2.1.0"},
-  {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.15.1"}}},
+  {emqtt, "1.15.1"},
   {prometheus, {git, "https://github.com/emqx/prometheus.erl", {tag, "v4.10.0.3"}}},
   {ranch, {git, "https://github.com/emqx/ranch", {tag, "2.2.0-emqx-3"}}},
   {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.13.0-emqx-2"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,9 @@
 
 {deps, [
   {getopt, "1.0.2"},
-  {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.6"}}},
+  {cowlib, "2.15.0"},
+  {gun, "2.1.0"},
+  {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.15.1"}}},
   {prometheus, {git, "https://github.com/emqx/prometheus.erl", {tag, "v4.10.0.3"}}},
   {cowlib, "2.14.0"},
   {ranch, {git, "https://github.com/emqx/ranch", {tag, "2.2.0-emqx-3"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,6 @@
   {gun, "2.1.0"},
   {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.15.1"}}},
   {prometheus, {git, "https://github.com/emqx/prometheus.erl", {tag, "v4.10.0.3"}}},
-  {cowlib, "2.14.0"},
   {ranch, {git, "https://github.com/emqx/ranch", {tag, "2.2.0-emqx-3"}}},
   {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.13.0-emqx-2"}}}
 ]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -37,8 +37,8 @@ Profiles = {profiles,[ {escript, []}
                                             , {copy, "topic_spec.json", "topic_spec.json"}
                                             , {template,"bin/emqtt_bench","bin/emqtt_bench"}
                                             ]}
-                                , {tar_hooks, [ "scripts/macos-sign-binaries.sh",
-                                                "scripts/macos-notarize-package.sh"]}
+                                %% @NOTE: below is needed to make overlay files actually get into the release tar file.
+                                , {tar_hooks, [ "echo dummy_tar_hook"]}
                                 , {include_src, false}
                                 , {include_erts, true}
                                 , {extended_start_script, false}

--- a/scripts/ensure-rebar3.sh
+++ b/scripts/ensure-rebar3.sh
@@ -13,7 +13,7 @@ case ${OTP_VSN} in
         VERSION="3.24.0-emqx-1"
         ;;
     27*)
-        VERSION="3.20.0-emqx-3"
+        VERSION="3.24.0-emqx-1"
         ;;
     26*)
         VERSION="3.20.0-emqx-1"

--- a/scripts/macos-notarize-package.sh
+++ b/scripts/macos-notarize-package.sh
@@ -3,17 +3,37 @@
 set -euo pipefail
 
 # intended to run on MacOS only
-if [ $(uname) != 'Darwin' ]; then
+if [ $(uname -o) != 'Darwin' ]; then
     echo 'Not macOS, exiting';
     exit 0;
 fi
 
-pushd "${RELX_TEMP_DIR}"
+RELX_OUTPUT_DIR="_build/emqtt_bench/rel/"
+# Find the tar.gz file created by relx
+TAR_GZ_FILE=$(realpath $(find "${RELX_OUTPUT_DIR}" -name "*.tar.gz" | tail -1))
 
-ZIP_PACKAGE_PATH="${1:-${RELX_OUTPUT_DIR}/${RELX_RELEASE_NAME}-${RELX_RELEASE_VSN}.zip}"
-zip -qr "${ZIP_PACKAGE_PATH}" .
+if [ -z "$TAR_GZ_FILE" ]; then
+    echo "No tar.gz file found in ${RELX_OUTPUT_DIR}"
+    exit 1
+fi
 
-popd
+echo "Found tar.gz: $TAR_GZ_FILE"
+
+# Create temporary directory for extraction
+TEMP_DIR=$(mktemp -d -p $PWD)
+trap "rm -rf $TEMP_DIR" EXIT
+
+echo "Extracting to temporary directory: $TEMP_DIR"
+tar -C "$TEMP_DIR" -xzf "$TAR_GZ_FILE"
+
+# Create zip from extracted contents
+ZIP_PACKAGE_PATH="${TAR_GZ_FILE%%.tar*}.zip"
+echo "Creating zip: $ZIP_PACKAGE_PATH"
+
+cd "$TEMP_DIR"
+zip -qr "$ZIP_PACKAGE_PATH" .
+
+echo "Zip file created successfully"
 
 if [[ "${APPLE_ID:-0}" == 0 || "${APPLE_ID_PASSWORD:-0}" == 0 || "${APPLE_TEAM_ID:-0}" == 0 ]]; then
     echo "Apple ID is not configured, skipping notarization."

--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -1055,7 +1055,7 @@ tcp_opts([{active, V} | Opts], Acc) ->
              end,
     tcp_opts(Opts, [{active, Active} | Acc]);
 tcp_opts([{lowmem, true} | Opts], Acc) ->
-    tcp_opts(Opts, [{recbuf, 64} , {sndbuf, 64} | Acc]);
+    tcp_opts(Opts, [{recbuf, 64} , {sndbuf, 64}, {buffer, 200} | Acc]);
 tcp_opts([{ifaddr, IfAddr} | Opts], Acc) ->
     case inet_parse:address(IfAddr) of
         {ok, IpAddr} ->

--- a/src/emqtt_bench.erl
+++ b/src/emqtt_bench.erl
@@ -49,6 +49,14 @@
 -define(COMMON_OPTS,
         [{help, undefined, "help", boolean,
           "help information"},
+         {active, $A, "active", {string, "once"},
+          "Config the client socket opt: " 
+          "\"once\": Legacy default. Suitable for high-concurrency clients with low message frequency. "
+          "\"true\": Highly active (recommended). Optimized for full speed; ideal for high-frequency messages and balanced scheduling. "
+          "\"false\": Disables receiving. "
+          "100: Starts slow but optimizes after 100 network packets are received. "
+          "* Use another integer value to fine-tune. "
+         },
          {dist, $d, "dist", boolean,
           "enable distribution port"},
          %% == Traffic related ==
@@ -1038,6 +1046,14 @@ tcp_opts(Opts) ->
     tcp_opts(Opts, []).
 tcp_opts([], Acc) ->
     Acc;
+tcp_opts([{active, V} | Opts], Acc) ->
+    Active = case V of
+                 "once" -> once;
+                 "true" -> true;
+                 "false" -> false;
+                 Int -> list_to_integer(Int)
+             end,
+    tcp_opts(Opts, [{active, Active} | Acc]);
 tcp_opts([{lowmem, true} | Opts], Acc) ->
     tcp_opts(Opts, [{recbuf, 64} , {sndbuf, 64} | Acc]);
 tcp_opts([{ifaddr, IfAddr} | Opts], Acc) ->


### PR DESCRIPTION
- bump emqtt. 1.15.1 for new arg `--active`
- ~~change macOS release to tar.gz~~
- prepare release 0.6.3
- fix strange macOS build release issue.

I cannot reproduce the problem on my macbook (same OTP, same rebar3) where github CI has issue of the Zip package of missing bin/emqtt_bench file.

it looks like a bug in emqx rebar3 fork, so workarounds are applied below:

1. Use the content of tar.gz as the source of true because rebar3 append Overlay files to the tar.gz file directly.
2. In github CI, the old 'tar hook' defined in the rebar.config.script  is executed before appending the Overlay files so we get a Zip file where `bin/emqtt_bench` is missing.
3. Overlay files injections are skipped if the `tar_hook` is undefined, so i have to add a dummy one.
4. Moved the hooks commands to the Makefile instead. 

We kept Zip file for macOS release as apple olny sign the Zip file